### PR TITLE
Inference.aggregate() memory optimizations

### DIFF
--- a/pyannote/audio/core/inference.py
+++ b/pyannote/audio/core/inference.py
@@ -560,7 +560,7 @@ class Inference(BaseInference):
         )
 
         masks = 1 - np.isnan(scores)
-        scores.data = np.nan_to_num(scores.data, copy=True, nan=0.0)
+        np.nan_to_num(scores.data, copy=False, nan=0.0)
 
         # Hamming window used for overlap-add aggregation
         hamming_window = (

--- a/pyannote/audio/core/inference.py
+++ b/pyannote/audio/core/inference.py
@@ -552,9 +552,6 @@ class Inference(BaseInference):
 
         num_chunks, num_frames_per_chunk, num_classes = scores.data.shape
 
-        masks = 1 - np.isnan(scores)
-        np.nan_to_num(scores.data, copy=False, nan=0.0)
-
         # Hamming window used for overlap-add aggregation
         hamming_window = (
             np.hamming(num_frames_per_chunk).reshape(-1, 1)
@@ -606,11 +603,13 @@ class Inference(BaseInference):
         )
 
         # loop on the scores of sliding chunks
-        for (chunk, score), (_, mask) in zip(scores, masks):
+        for chunk, score in scores:
             # chunk ~ Segment
             # score ~ (num_frames_per_chunk, num_classes)-shaped np.ndarray
             # mask ~ (num_frames_per_chunk, num_classes)-shaped np.ndarray
-
+            mask = 1 - np.isnan(score)
+            np.nan_to_num(score, copy=False, nan=0.0)
+            
             start_frame = frames.closest_frame(chunk.start + 0.5 * frames.duration)
 
             aggregated_output[start_frame : start_frame + num_frames_per_chunk] += (

--- a/pyannote/audio/core/inference.py
+++ b/pyannote/audio/core/inference.py
@@ -552,13 +552,6 @@ class Inference(BaseInference):
 
         num_chunks, num_frames_per_chunk, num_classes = scores.data.shape
 
-        chunks = scores.sliding_window
-        frames = SlidingWindow(
-            start=chunks.start,
-            duration=frames.duration,
-            step=frames.step,
-        )
-
         masks = 1 - np.isnan(scores)
         np.nan_to_num(scores.data, copy=False, nan=0.0)
 


### PR DESCRIPTION
with these changes, memory usage decreases by ~20GB for 9 hour audio files